### PR TITLE
Move from sunlightfoundation.org to self-hosted API

### DIFF
--- a/lib/congress/connection.rb
+++ b/lib/congress/connection.rb
@@ -2,7 +2,7 @@ require 'faraday_middleware'
 
 module Congress
   module Connection
-    ENDPOINT = 'https://congress.api.sunlightfoundation.com'.freeze
+    ENDPOINT = 'https://sunlight.countable.us'.freeze
 
   private
 

--- a/lib/congress/version.rb
+++ b/lib/congress/version.rb
@@ -1,3 +1,3 @@
 module Congress
-  VERSION = '0.2.3'
+  VERSION = '0.2.6'
 end


### PR DESCRIPTION
Also, bump version to 0.2.6.  Upstream is now at 0.3.0, and uses 2.5 and 2.4.